### PR TITLE
Get translated value for account name if it exists in user language.

### DIFF
--- a/account_financial_report_qweb/report/general_ledger.py
+++ b/account_financial_report_qweb/report/general_ledger.py
@@ -395,7 +395,7 @@ WITH
             SELECT
                 a.id,
                 a.code,
-                a.name,
+                coalesce(t.value, a.name) AS name,
                 a.internal_type IN ('payable', 'receivable')
                     AS is_partner_account,
                 a.user_type_id,
@@ -435,6 +435,14 @@ WITH
                     ON
                         atml.account_analytic_tag_id = aat.id
                         AND aat.id IN %s
+            """
+        query_inject_account += """
+            LEFT JOIN
+                ir_translation t
+                    ON
+                        a.id = t.res_id
+                        AND t.name = 'account.account,name'
+                        AND t.lang = %s
             """
         query_inject_account += """
             WHERE
@@ -567,6 +575,7 @@ AND
                 tuple(self.filter_analytic_tag_ids.ids),
             )
         query_inject_account_params += (
+            self.env.user.lang,
             self.company_id.id,
             self.unaffected_earnings_account.id,
         )

--- a/account_financial_report_qweb/report/journal_report.py
+++ b/account_financial_report_qweb/report/journal_report.py
@@ -291,7 +291,7 @@ class ReportJournalQweb(models.TransientModel):
                 rjqm.id as report_move_id,
                 aml.id as move_line_id,
                 aml.account_id as account_id,
-                aa.name as account,
+                coalesce(t.value, aa.name) as account,
                 aa.code as account_code,
                 aa.internal_type as account_type,
                 aml.partner_id as partner_id,
@@ -337,6 +337,12 @@ class ReportJournalQweb(models.TransientModel):
                 account_account aa
                     on (aa.id = aml.account_id)
             LEFT JOIN
+                ir_translation t
+                    ON
+                        aa.id = t.res_id
+                        AND t.name = 'account.account,name'
+                        AND t.lang = %s
+            LEFT JOIN
                 res_partner p
                     on (p.id = aml.partner_id)
             LEFT JOIN
@@ -350,6 +356,7 @@ class ReportJournalQweb(models.TransientModel):
         """
         params = (
             self.env.uid,
+            self.env.user.lang,
             self.id,
         )
         self.env.cr.execute(sql, params)

--- a/account_financial_report_qweb/report/trial_balance.py
+++ b/account_financial_report_qweb/report/trial_balance.py
@@ -291,7 +291,7 @@ SELECT
     acc.id,
     acc.group_id,
     acc.code,
-    acc.name,
+    coalesce(t.value, acc.name) AS name,
     coalesce(rag.initial_balance, 0) AS initial_balance,
     coalesce(rag.final_debit - rag.initial_debit, 0) AS debit,
     coalesce(rag.final_credit - rag.initial_credit, 0) AS credit,
@@ -306,6 +306,12 @@ FROM
     account_account acc
     LEFT OUTER JOIN report_general_ledger_qweb_account AS rag
         ON rag.account_id = acc.id AND rag.report_id = %s
+    LEFT JOIN
+        ir_translation t
+            ON
+                acc.id = t.res_id
+                AND t.name = 'account.account,name'
+                AND t.lang = %s
 WHERE
     acc.id in %s
         """
@@ -313,6 +319,7 @@ WHERE
             self.id,
             self.env.uid,
             self.general_ledger_id.id,
+            self.env.user.lang,
             account_ids._ids,
         )
         self.env.cr.execute(query_inject_account, query_inject_account_params)


### PR DESCRIPTION
When l10n_multilang module is installed, the name of the accounts displayed in the reports should be taken from the ir_translation table when a translation exists.