### PR TITLE
Add general ledger qweb display opposite accounts

### DIFF
--- a/account_financial_report_qweb/__manifest__.py
+++ b/account_financial_report_qweb/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'QWeb Financial Reports',
-    'version': '10.0.3.0.1',
+    'version': '10.0.3.0.2',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'
@@ -16,7 +16,7 @@
     "website": "https://odoo-community.org/",
     'depends': [
         'account',
-        'account_group',    # account-financial-tools
+        'account_group',  # account-financial-tools
         'date_range',
         'report_xlsx',
         'report',

--- a/account_financial_report_qweb/i18n/account_financial_report_qweb.pot
+++ b/account_financial_report_qweb/i18n/account_financial_report_qweb.pot
@@ -88,7 +88,7 @@ msgid "Account at 0 filter"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:95
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:97
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:66
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_filters
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_open_items_qweb_filters
@@ -265,7 +265,7 @@ msgstr ""
 
 #. module: account_financial_report_qweb
 #: code:addons/account_financial_report_qweb/report/aged_partner_balance_xlsx.py:132
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:92
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:94
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:64
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:113
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_aged_partner_balance_filters
@@ -278,7 +278,7 @@ msgstr ""
 
 #. module: account_financial_report_qweb
 #: code:addons/account_financial_report_qweb/report/aged_partner_balance_xlsx.py:131
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:91
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:93
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:64
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:112
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_aged_partner_balance_filters
@@ -296,7 +296,7 @@ msgid "Amount Currency"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:72
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:74
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_lines
 #, python-format
 msgid "Amount cur."
@@ -393,7 +393,7 @@ msgid "Centralize"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:99
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:101
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_filters
 #, python-format
 msgid "Centralize filter"
@@ -405,7 +405,7 @@ msgid "Centralized"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger.py:1434
+#: code:addons/account_financial_report_qweb/report/general_ledger.py:1451
 #, python-format
 msgid "Centralized Entries"
 msgstr ""
@@ -481,7 +481,7 @@ msgid "Cost\n"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:34
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:36
 #: model:ir.model.fields,field_description:account_financial_report_qweb.field_report_general_ledger_qweb_move_line_cost_center
 #, python-format
 msgid "Cost center"
@@ -550,7 +550,7 @@ msgid "Created on"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:51
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:53
 #: code:addons/account_financial_report_qweb/report/journal_report_xlsx.py:73
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:35
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:76
@@ -609,14 +609,14 @@ msgid "Cumul older"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:58
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:60
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_lines
 #, python-format
 msgid "Cumul. Bal."
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:67
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:69
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:43
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:50
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:91
@@ -735,7 +735,7 @@ msgid "Date range"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:86
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:88
 #: code:addons/account_financial_report_qweb/report/journal_report_xlsx.py:175
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:109
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_filters
@@ -754,7 +754,7 @@ msgid "Date to"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:44
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:46
 #: code:addons/account_financial_report_qweb/report/journal_report_xlsx.py:67
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:31
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:72
@@ -845,7 +845,7 @@ msgid "Ending\n"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:190
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:192
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:122
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:43
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:58
@@ -1045,7 +1045,7 @@ msgid "From:"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:87
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:89
 #: code:addons/account_financial_report_qweb/report/journal_report_xlsx.py:176
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:110
 #, python-format
@@ -1108,7 +1108,7 @@ msgid "Group option"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:96
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:98
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:67
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:115
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_filters
@@ -1197,7 +1197,7 @@ msgid "Initial\n"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:178
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:180
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:27
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:54
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:68
@@ -1488,9 +1488,9 @@ msgid "Name"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:100
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:104
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:108
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:102
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:106
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:110
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:69
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:117
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_filters
@@ -1518,10 +1518,10 @@ msgid "No limit"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger.py:756
-#: code:addons/account_financial_report_qweb/report/general_ledger.py:1138
-#: code:addons/account_financial_report_qweb/report/open_items.py:306
-#: code:addons/account_financial_report_qweb/report/open_items.py:555
+#: code:addons/account_financial_report_qweb/report/general_ledger.py:766
+#: code:addons/account_financial_report_qweb/report/general_ledger.py:1149
+#: code:addons/account_financial_report_qweb/report/open_items.py:313
+#: code:addons/account_financial_report_qweb/report/open_items.py:562
 #, python-format
 msgid "No partner allocated"
 msgstr ""
@@ -1603,6 +1603,14 @@ msgid "Open items id"
 msgstr ""
 
 #. module: account_financial_report_qweb
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:32
+#: model:ir.model.fields,field_description:account_financial_report_qweb.field_report_general_ledger_qweb_move_line_opposite_accounts
+#: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_lines
+#, python-format
+msgid "Opposite accounts"
+msgstr ""
+
+#. module: account_financial_report_qweb
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.journal_report_wizard_form_view
 msgid "Options"
 msgstr ""
@@ -1622,7 +1630,7 @@ msgstr ""
 #. module: account_financial_report_qweb
 #: code:addons/account_financial_report_qweb/report/aged_partner_balance_xlsx.py:25
 #: code:addons/account_financial_report_qweb/report/aged_partner_balance_xlsx.py:74
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:32
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:34
 #: code:addons/account_financial_report_qweb/report/journal_report_xlsx.py:52
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:28
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:67
@@ -1648,7 +1656,7 @@ msgid "Partner\n"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:175
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:177
 #, python-format
 msgid "Partner Initial balance"
 msgstr ""
@@ -1660,7 +1668,7 @@ msgid "Partner cumul aged balance"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:187
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:189
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:118
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_ending_cumul
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_open_items_qweb_ending_cumul
@@ -1753,7 +1761,7 @@ msgid "Posted"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:40
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:42
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_lines
 #, python-format
 msgid "Rec."
@@ -1777,7 +1785,7 @@ msgstr ""
 
 #. module: account_financial_report_qweb
 #: code:addons/account_financial_report_qweb/report/aged_partner_balance_xlsx.py:75
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:33
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:35
 #: code:addons/account_financial_report_qweb/report/journal_report_xlsx.py:57
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:29
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_journal_qweb_journal_table_header
@@ -1872,7 +1880,7 @@ msgid "Sequence"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:96
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:98
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:67
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:115
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_filters
@@ -1883,7 +1891,7 @@ msgid "Show"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:103
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:105
 #: model:ir.model.fields,field_description:account_financial_report_qweb.field_general_ledger_report_wizard_show_analytic_tags
 #: model:ir.model.fields,field_description:account_financial_report_qweb.field_report_general_ledger_qweb_show_analytic_tags
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_filters
@@ -1897,7 +1905,7 @@ msgid "Show cost center"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:107
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:109
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:68
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:116
 #: model:ir.model.fields,field_description:account_financial_report_qweb.field_general_ledger_report_wizard_foreign_currency
@@ -1935,7 +1943,7 @@ msgid "Start date"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:37
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:39
 #: model:ir.model.fields,field_description:account_financial_report_qweb.field_report_general_ledger_qweb_move_line_tags
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_lines
 #, python-format
@@ -1952,7 +1960,7 @@ msgstr ""
 
 #. module: account_financial_report_qweb
 #: code:addons/account_financial_report_qweb/report/aged_partner_balance_xlsx.py:130
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:90
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:92
 #: code:addons/account_financial_report_qweb/report/journal_report_xlsx.py:179
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:63
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:111
@@ -2140,9 +2148,9 @@ msgid "With account name"
 msgstr ""
 
 #. module: account_financial_report_qweb
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:100
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:104
-#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:108
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:102
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:106
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:110
 #: code:addons/account_financial_report_qweb/report/open_items_xlsx.py:69
 #: code:addons/account_financial_report_qweb/report/trial_balance_xlsx.py:117
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_filters

--- a/account_financial_report_qweb/i18n/fr.po
+++ b/account_financial_report_qweb/i18n/fr.po
@@ -1651,6 +1651,14 @@ msgid "Open items id"
 msgstr "Open items id"
 
 #. module: account_financial_report_qweb
+#: code:addons/account_financial_report_qweb/report/general_ledger_xlsx.py:32
+#: model:ir.model.fields,field_description:account_financial_report_qweb.field_report_general_ledger_qweb_move_line_opposite_accounts
+#: model:ir.ui.view,arch_db:account_financial_report_qweb.report_general_ledger_lines
+#, python-format
+msgid "Opposite accounts"
+msgstr "Contreparties"
+
+#. module: account_financial_report_qweb
 #: model:ir.ui.view,arch_db:account_financial_report_qweb.journal_report_wizard_form_view
 msgid "Options"
 msgstr ""

--- a/account_financial_report_qweb/report/general_ledger_xlsx.py
+++ b/account_financial_report_qweb/report/general_ledger_xlsx.py
@@ -29,25 +29,27 @@ class GeneralLedgerXslx(abstract_report_xlsx.AbstractReportXslx):
             4: {'header': _('Taxes'),
                 'field': 'taxes_description',
                 'width': 15},
-            5: {'header': _('Partner'), 'field': 'partner', 'width': 25},
-            6: {'header': _('Ref - Label'), 'field': 'label', 'width': 40},
-            7: {'header': _('Cost center'),
+            5: {'header': _('Opposite accounts'),
+                'field': 'opposite_accounts', 'width': 25},
+            6: {'header': _('Partner'), 'field': 'partner', 'width': 25},
+            7: {'header': _('Ref - Label'), 'field': 'label', 'width': 40},
+            8: {'header': _('Cost center'),
                 'field': 'cost_center',
                 'width': 15},
-            8: {'header': _('Tags'),
+            9: {'header': _('Tags'),
                 'field': 'tags',
                 'width': 10},
-            9: {'header': _('Rec.'),
-                'field': 'matched_ml_id',
-                'type': 'many2one',
-                'width': 5},
-            10: {'header': _('Debit'),
+            10: {'header': _('Rec.'),
+                 'field': 'matched_ml_id',
+                 'type': 'many2one',
+                 'width': 5},
+            11: {'header': _('Debit'),
                  'field': 'debit',
                  'field_initial_balance': 'initial_debit',
                  'field_final_balance': 'final_debit',
                  'type': 'amount',
                  'width': 14},
-            11: {
+            12: {
                 'header': _('Credit'),
                 'field': 'credit',
                 'field_initial_balance': 'initial_credit',
@@ -55,7 +57,7 @@ class GeneralLedgerXslx(abstract_report_xlsx.AbstractReportXslx):
                 'type': 'amount',
                 'width': 14
             },
-            12: {'header': _('Cumul. Bal.'),
+            13: {'header': _('Cumul. Bal.'),
                  'field': 'cumul_balance',
                  'field_initial_balance': 'initial_balance',
                  'field_final_balance': 'final_balance',
@@ -64,12 +66,12 @@ class GeneralLedgerXslx(abstract_report_xlsx.AbstractReportXslx):
         }
         if report.foreign_currency:
             foreign_currency = {
-                13: {'header': _('Cur.'),
+                14: {'header': _('Cur.'),
                      'field': 'currency_id',
                      'field_currency_balance': 'currency_id',
                      'type': 'many2one',
                      'width': 7},
-                14: {'header': _('Amount cur.'),
+                15: {'header': _('Amount cur.'),
                      'field': 'amount_currency',
                      'field_initial_balance':
                          'initial_balance_foreign_currency',
@@ -116,13 +118,13 @@ class GeneralLedgerXslx(abstract_report_xlsx.AbstractReportXslx):
         return 2
 
     def _get_col_pos_initial_balance_label(self):
-        return 5
+        return 6
 
     def _get_col_count_final_balance_name(self):
-        return 5
+        return 6
 
     def _get_col_pos_final_balance_label(self):
-        return 5
+        return 6
 
     def _generate_report_content(self, workbook, report):
         # For each account

--- a/account_financial_report_qweb/report/templates/general_ledger.xml
+++ b/account_financial_report_qweb/report/templates/general_ledger.xml
@@ -127,6 +127,9 @@
                     <div class="act_as_cell" style="width: 4.70%;">Account</div>
                     <!--## account code-->
                     <div class="act_as_cell" style="width: 8.89%;">Taxes</div>
+                    <!--## opposite accounts-->
+                    <div class="act_as_cell" style="width: 10.0%;">Opposite accounts
+                    </div>
                     <!--## partner-->
                     <div class="act_as_cell" style="width: 10.0%;">Partner
                     </div>
@@ -170,6 +173,8 @@
                 <!--## account code-->
                 <div class="act_as_cell"/>
                 <!--## taxes-->
+                <div class="act_as_cell"/>
+                <!--## opposite accounts-->
                 <div class="act_as_cell"/>
                 <!--## partner-->
                 <div class="act_as_cell"/>
@@ -364,6 +369,7 @@
                     </div>
                     <!--## taxes-->
                     <div class="act_as_cell left"><span t-field="line.taxes_description"/></div>
+                    <div class="act_as_cell left"><span t-field="line.opposite_accounts"/></div>
                     <!--## partner-->
                     <div class="act_as_cell left">
                         <t t-set="res_model" t-value="'res.partner'"/>


### PR DESCRIPTION
Display the list of account codes of the opposite move lines in the same move as the currently displayed line in the general ledger report.